### PR TITLE
cater for changed API in Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,36 @@
 language: python
+language: python
 python:
   - "2.7"
-
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 env:
-  matrix:
-    - TOX_ENV=py27-1.10
-    - TOX_ENV=py34-1.10
-    - TOX_ENV=py35-1.10
-    - TOX_ENV=py27-1.9
-    - TOX_ENV=py34-1.9
-    - TOX_ENV=py35-1.9
-    - TOX_ENV=py27-1.8
-    - TOX_ENV=py33-1.8
-    - TOX_ENV=py34-1.8
-    - TOX_ENV=py35-1.8
-    - TOX_ENV=py27-1.7
-    - TOX_ENV=py33-1.7
-    - TOX_ENV=py34-1.7
+  - DJANGO=1.8
+  - DJANGO=1.10
+  - DJANGO=1.11
+  - DJANGO=master
+matrix:
+  exclude:
+    - python: "2.7"
+      env: DJANGO=master
+    - python: "3.3"
+      env: DJANGO=1.10
+    - python: "3.3"
+      env: DJANGO=1.11
+    - python: "3.3"
+      env: DJANGO=master
+    - python: "3.4"
+      env: DJANGO=master
+    - python: "3.5"
+      env: DJANGO=master
+    - python: "3.6"
+      env: DJANGO=1.8
+    - python: "3.6"
+      env: DJANGO=1.10
+    - python: "3.6"
+      env: DJANGO=master
 
 install:
   - pip install -U setuptools wheel
@@ -25,7 +39,7 @@ install:
   - pip install tox
 
 script:
-  - tox -e $TOX_ENV
+  - tox -e py${TRAVIS_PYTHON_VERSION//[.]/}-$DJANGO
 
 after_success:
   - coveralls

--- a/cid/backends/mysql/base.py
+++ b/cid/backends/mysql/base.py
@@ -5,6 +5,9 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BaseMySQLWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name=None):
+        if name:
+            base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        else:
+            base_cursor = super(DatabaseWrapper, self).create_cursor()
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/oracle/base.py
+++ b/cid/backends/oracle/base.py
@@ -7,6 +7,9 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BaseOracleWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name=None):
+        if name:
+            base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        else:
+            base_cursor = super(DatabaseWrapper, self).create_cursor()
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/postgresql/base.py
+++ b/cid/backends/postgresql/base.py
@@ -7,6 +7,9 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BasePostgresqlWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name=None):
+        if name:
+            base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        else:
+            base_cursor = super(DatabaseWrapper, self).create_cursor()
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/sqlite3/base.py
+++ b/cid/backends/sqlite3/base.py
@@ -7,6 +7,9 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BaseSqliteWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name=None):
+        if name:
+            base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        else:
+            base_cursor = super(DatabaseWrapper, self).create_cursor()
         return CidCursorWrapper(base_cursor)

--- a/cid/locals.py
+++ b/cid/locals.py
@@ -1,5 +1,7 @@
 from threading import local
+from uuid import uuid4
 
+from django.conf import settings
 
 _thread_locals = local()
 
@@ -15,4 +17,10 @@ def get_cid():
     """
     Retrieves the currently set Correlation Id
     """
-    return getattr(_thread_locals, 'CID', None)
+    cid = getattr(_thread_locals, 'CID', None)
+
+    if cid is None and getattr(settings, 'CID_GENERATE', False):
+        cid = str(uuid4())
+        set_cid(cid)
+
+    return cid

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -25,16 +25,16 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-)
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -42,7 +42,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 
 ROOT_URLCONF = 'urls'
 

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,14 +1,13 @@
 from django.conf.urls import include, url
-from django.contrib import admin
 
 from .views import ping_view
 
 
-urlpatterns = (
+urlpatterns = [
     # Examples:
     # url(r'^$', 'sandbox.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
     url(r'^ping/$', ping_view, name='ping'),
-    url(r'^admin/', include(admin.site.urls)),
-)
+    # url(r'^admin/', include(admin.site.urls)),
+]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,7 @@
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from mock import Mock, patch
@@ -90,8 +93,10 @@ class TestCidMiddleware(TestCase):
         self.assertNotIn('X_CORRELATION_ID', response.keys())
 
     @override_settings(
-        MIDDLEWARE_CLASSES=('cid.middleware.CidMiddleware', ),
+        MIDDLEWARE=('cid.middleware.CidMiddleware', ),
         CID_GENERATE=True,
+        # FIXME: this is only necessary until Django-1.8 support is dropped
+        MIDDLEWARE_CLASSES=('cid.middleware.CidMiddleware', ),
     )
     def test_integration(self):
         """Assert the middleware works with the Django initialization"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,88 +1,22 @@
 [tox]
-envlist = py27-1.10, py34-1.10, py35-1.10, py27-1.9, py34-1.9, py35-1.9, py27-1.8, py33-1.8, py34-1.8, py35-1.8, py27-1.7, py33-1.7, py34-1.7, docs
+envlist =
+    py27-{1.8,1.10,1.11},
+    py32-{1.8},
+    py33-{1.8},
+    py34-{1.8,1.10,1.11,master},
+    py35-{1.8,1.10,1.11,master},
+    py36-{1.11,master}
 
 [testenv]
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    1.8: Django>=1.8,<1.9
+    1.10: Django>=1.10,<1.11
+    1.11: Django>=1.11,<1.12
+    master: https://github.com/django/django/tarball/master
 commands = python runtests.py
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cid
-
-[testenv:py27-1.10]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.10,<1.11
-
-[testenv:py34-1.10]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.10,<1.11
-
-[testenv:py35-1.10]
-basepython = python3.5
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.10,<1.11
-
-[testenv:py27-1.9]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.9,<1.10
-
-[testenv:py34-1.9]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.9,<1.10
-
-[testenv:py35-1.9]
-basepython = python3.5
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.9,<1.10
-
-[testenv:py27-1.8]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py33-1.8]
-basepython = python3.3
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py34-1.8]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py35-1.8]
-basepython = python3.5
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py27-1.7]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.7,<1.8
-
-[testenv:py33-1.7]
-basepython = python3.3
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.7,<1.8
-
-[testenv:py34-1.7]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.7,<1.8
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
as mentioned on https://docs.djangoproject.com/en/1.11/releases/1.11/#database-backend-api:
"The name keyword argument is added to the DatabaseWrapper.create_cursor(self, name=None) method to allow usage of server-side cursors on backends that support it."
(currently only postgresql)

also adjusted tox.ini and .travis.yml to consider the currently supported versions