### PR TITLE
enable to customize SQL comment prefix

### DIFF
--- a/cid/cursor.py
+++ b/cid/cursor.py
@@ -1,4 +1,9 @@
+from django.conf import settings
 from .locals import get_cid
+
+
+def _base_comment_formatter(cid):
+    return 'cid: {}'.format(cid)
 
 
 class CidCursorWrapper(object):
@@ -24,10 +29,13 @@ class CidCursorWrapper(object):
         self.close()
 
     def add_comment(self, sql):
+        cid_sql_formatter = getattr(
+            settings, 'CID_SQL_COMMENT_FORMATTER', _base_comment_formatter
+        )
         cid = get_cid()
         if cid:
             cid = cid.replace('/*', '\/\*').replace('*/', '\*\/')
-            return "/* cid: {} */\n{}".format(cid, sql)
+            return "/* {} */\n{}".format(cid_sql_formatter(cid), sql)
         return sql
 
     # The following methods cannot be implemented in __getattr__, because the

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -16,3 +16,7 @@ Settings
     ``CID_GENERATE``
         Tell the cid middleware to generate a correlation id if it doesn't
         already exist. Default value: ``False``.
+
+    ``CID_SQL_COMMENT_FORMATTER``
+        Function taking a cid as argument and returning the str that will be
+        added as a SQL comment. Default returned value: ``cid: MY_CID``.

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.test.utils import override_settings
 from mock import Mock, patch
 
 from cid.cursor import CidCursorWrapper
@@ -16,6 +17,16 @@ class TestCidCursor(TestCase):
     def test_adds_comment(self, get_cid):
         get_cid.return_value = 'testing-cursor'
         expected = "/* cid: testing-cursor */\nSELECT 1;"
+        self.assertEqual(
+            expected,
+            self.cursor_wrapper.add_comment("SELECT 1;")
+        )
+
+    @override_settings(CID_SQL_COMMENT_FORMATTER=lambda cid: 'correlation_id={}'.format(cid))
+    @patch('cid.cursor.get_cid')
+    def test_adds_comment_setting_overriden(self, get_cid):
+        get_cid.return_value = 'testing-cursor'
+        expected = "/* correlation_id=testing-cursor */\nSELECT 1;"
         self.assertEqual(
             expected,
             self.cursor_wrapper.add_comment("SELECT 1;")


### PR DESCRIPTION
In our use case, it would be very handy to be able to have the SQL
comments formatted as correlation_id=XXX.
We are using Splunk and this would provide auto-indexing for the
correlation_id field.