### PR TITLE
Drop support of old versions of Python and Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 env:
-  - DJANGO="1.7"
-  - DJANGO="1.8"
-  - DJANGO="1.9"
-  - DJANGO="1.10"
+  - DJANGO="1.11"
 
 install:
   - pip install -U setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ env:
   - DJANGO="1.11"
 
 install:
-  - pip install -U setuptools wheel
-  - python setup.py develop
-  - pip install --use-wheel -U -r requirements/ci.txt
-  - pip install tox
+  - pip install -r requirements/ci.txt
+  - pip install -e .
   - pip install tox-travis
 
 script:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,7 +2,9 @@
 Credits
 =======
 
-* Jonathan Moss <jonathan.moss@snowballone.com.au>
+Original author: Jonathan Moss <jonathan.moss@snowballone.com.au>
+Current maintainers: the (mostly) nice people at Polyconseil
+
+Contributors:
+
 * Francis Reyes <francis.reyes@snowballone.com.au>
-* Damien Baty <github: @dbaty>
-* BEY Quentin <github: @qbey>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,6 +98,6 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4, 3.5 and for PyPy.
+3. The pull request should work for all supported versions of Python and Django.
    Check https://travis-ci.org/snowball-one/cid/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,3 +25,4 @@ History
 * Drop support of Python 2.6.
 * Generate cid outside of the middleware when ``GENERATE_CID`` is
   enabled, so that it's available even if the middleware is not used
+* Fix support of Django 1.11 in database backends.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,5 +21,7 @@ History
 0.3 (unreleased)
 ++++++++++++++++
 
-* Drop support of Django < 1.11
-* Drop support of Python 2.6
+* Drop support of Django < 1.11.
+* Drop support of Python 2.6.
+* Generate cid outside of the middleware when ``GENERATE_CID`` is
+  enabled, so that it's available even if the middleware is not used

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,7 +22,7 @@ History
 ++++++++++++++++
 
 * Drop support of Django < 1.11.
-* Drop support of Python 2.6.
+* Drop support of Python 2.
 * Generate cid outside of the middleware when ``GENERATE_CID`` is
   enabled, so that it's available even if the middleware is not used
 * Fix support of Django 1.11 in database backends.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,3 +17,9 @@ History
 ++++++++++++++++++
 
 * Added support for Django 1.10 middleware (thanks @qbey)
+
+0.3 (unreleased)
+++++++++++++++++
+
+* Drop support of Django < 1.11
+* Drop support of Python 2.6

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Supported versions
 
 We currently support the following versions:
 
-- Django 1.11: Python 2.7 or Python >=3.4
+- Django 1.11 with Python >=3.4.
 
 Other versions may work but are not supported.
 

--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,15 @@ Features
 * Output correlation id as a header
 
 Documentation can be found at:  http://django-correlation-id.readthedocs.org/
+
+
+Supported versions
+------------------
+
+We currently support the following versions:
+
+- Django 1.11: Python 2.7 or Python >=3.4
+
+Other versions may work but are not supported.
+
+Django 2 support will soon be added.

--- a/cid/backends/mysql/base.py
+++ b/cid/backends/mysql/base.py
@@ -6,5 +6,5 @@ from ...cursor import CidCursorWrapper
 class DatabaseWrapper(BaseMySQLWrapper):
 
     def create_cursor(self, name):
-        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        base_cursor = super().create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/mysql/base.py
+++ b/cid/backends/mysql/base.py
@@ -5,6 +5,6 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BaseMySQLWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name):
+        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/oracle/base.py
+++ b/cid/backends/oracle/base.py
@@ -7,6 +7,6 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BaseOracleWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name):
+        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/postgresql/base.py
+++ b/cid/backends/postgresql/base.py
@@ -8,5 +8,5 @@ from ...cursor import CidCursorWrapper
 class DatabaseWrapper(BasePostgresqlWrapper):
 
     def create_cursor(self, name):
-        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        base_cursor = super().create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/postgresql/base.py
+++ b/cid/backends/postgresql/base.py
@@ -7,6 +7,6 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BasePostgresqlWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name):
+        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/sqlite3/base.py
+++ b/cid/backends/sqlite3/base.py
@@ -8,5 +8,5 @@ from ...cursor import CidCursorWrapper
 class DatabaseWrapper(BaseSqliteWrapper):
 
     def create_cursor(self, name):
-        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
+        base_cursor = super().create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/backends/sqlite3/base.py
+++ b/cid/backends/sqlite3/base.py
@@ -7,6 +7,6 @@ from ...cursor import CidCursorWrapper
 
 class DatabaseWrapper(BaseSqliteWrapper):
 
-    def create_cursor(self):
-        base_cursor = super(DatabaseWrapper, self).create_cursor()
+    def create_cursor(self, name):
+        base_cursor = super(DatabaseWrapper, self).create_cursor(name)
         return CidCursorWrapper(base_cursor)

--- a/cid/locals.py
+++ b/cid/locals.py
@@ -1,5 +1,7 @@
 from threading import local
+import uuid
 
+from django.conf import settings
 
 _thread_locals = local()
 
@@ -15,4 +17,8 @@ def get_cid():
     """
     Retrieves the currently set Correlation Id
     """
-    return getattr(_thread_locals, 'CID', None)
+    cid = getattr(_thread_locals, 'CID', None)
+    if cid is None and getattr(settings, 'CID_GENERATE', False):
+        cid = str(uuid.uuid4())
+        set_cid(cid)
+    return cid

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,10 +1,7 @@
 from uuid import uuid4
-from django.conf import settings
 
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:  # Django < 1.10
-    MiddlewareMixin = object
+from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 from .locals import set_cid, get_cid
 

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
@@ -20,14 +18,13 @@ class CidMiddleware(MiddlewareMixin):
         self.cid_response_header = getattr(
             settings, 'CID_RESPONSE_HEADER', self.cid_request_header
         )
-        self.generate_cid = getattr(settings, 'CID_GENERATE', False)
 
     def process_request(self, request):
         cid = request.META.get(self.cid_request_header, None)
-        if cid is None and self.generate_cid:
-            cid = str(uuid4())
+        if cid is None:
+            cid = get_cid()
         request.correlation_id = cid
-        set_cid(request.correlation_id)
+        set_cid(cid)
 
     def process_response(self, request, response):
         cid = get_cid()

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -11,7 +11,7 @@ class CidMiddleware(MiddlewareMixin):
     """
 
     def __init__(self, *args, **kwargs):
-        super(CidMiddleware, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.cid_request_header = getattr(
             settings, 'CID_HEADER', 'X_CORRELATION_ID'
         )

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     description="""Correlation IDs in Django for debugging requests""",
     long_description=readme + '\n\n' + history,
     author='Snowball One',
-    author_email='opensource@snowballone.com.au',
+    maintainer="Polyconseil",
+    maintainer_email="opensource+django-cid@polyconseil.fr",
     url='https://github.com/snowball-digital/cid',
     packages=[
         'cid',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from mock import Mock, patch
 
+import cid.locals
 from cid.middleware import CidMiddleware
 
 
@@ -10,6 +11,10 @@ class TestCidMiddleware(TestCase):
 
     def setUp(self):
         self.cid = 'test-cid'
+
+    def tearDown(self):
+        super().tearDown()
+        cid.locals.set_cid(None)  # don't leak cid between each test
 
     def get_mock_request(self, cid=None):
         request = Mock()
@@ -32,7 +37,7 @@ class TestCidMiddleware(TestCase):
         middleware.process_request(request)
         set_cid.assert_called_with(None)
 
-    @patch('cid.middleware.uuid4')
+    @patch('uuid.uuid4')
     @patch('cid.middleware.set_cid')
     @override_settings(CID_GENERATE=True)
     def test_process_request_generates_uuid(self, set_cid, uuid4):

--- a/tox.ini
+++ b/tox.ini
@@ -1,106 +1,58 @@
 [tox]
-envlist = py{27,34,35}-django1.{9,10}, py{27, 33, 34, 35}-django1.8, py{27, 33, 34}-django1.7, docs
+envlist = py{27,34,35,36,37}-django1.11, docs
 
 [travis]
 python =
   2.7: py27
   3.4: py34, docs
+  3.5: py35, docs
+  3.6: py36, docs
+  3.7: py37, docs
 
 [travis:env]
 DJANGO =
-  1.7: django1.7
-  1.8: django1.8, docs
-  1.9: django1.9
-  1.10: django1.10
+  1.11: django1.11, docs
 
 [testenv]
 commands = python runtests.py
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cid
 
-[testenv:py27-django1.10]
+[testenv:py27-django1.11]
 basepython = python2.7
 deps =
     -r{toxinidir}/requirements/ci.txt
-    django>=1.10,<1.11
+    django>=1.11,<2
 
-[testenv:py34-django1.10]
+[testenv:py34-django1.11]
 basepython = python3.4
 deps =
     -r{toxinidir}/requirements/ci.txt
-    django>=1.10,<1.11
+    django>=1.11,<2
 
-[testenv:py35-django1.10]
+[testenv:py35-django1.11]
 basepython = python3.5
 deps =
     -r{toxinidir}/requirements/ci.txt
-    django>=1.10,<1.11
+    django>=1.11,<2
 
-[testenv:py27-django1.9]
-basepython = python2.7
+[testenv:py36-django1.11]
+basepython = python3.6
 deps =
     -r{toxinidir}/requirements/ci.txt
-    django>=1.9,<1.10
+    django>=1.11,<2
 
-[testenv:py34-django1.9]
-basepython = python3.4
+[testenv:py37-django1.11]
+basepython = python3.7
 deps =
     -r{toxinidir}/requirements/ci.txt
-    django>=1.9,<1.10
-
-[testenv:py35-django1.9]
-basepython = python3.5
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.9,<1.10
-
-[testenv:py27-django1.8]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py33-django1.8]
-basepython = python3.3
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py34-django1.8]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py35-django1.8]
-basepython = python3.5
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
-
-[testenv:py27-django1.7]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.7,<1.8
-
-[testenv:py33-django1.7]
-basepython = python3.3
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.7,<1.8
-
-[testenv:py34-django1.7]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.7,<1.8
+    django>=1.11,<2
 
 [testenv:docs]
 changedir = docs
 deps =
     Sphinx==1.7.0
     -r{toxinidir}/requirements/ci.txt
-    django>=1.8,<1.9
+    django>=1.11,<2
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{27,34,35,36,37}-django1.11, docs
+envlist = py{34,35,36,37}-django1.11, docs
 
 [travis]
 python =
-  2.7: py27
   3.4: py34, docs
   3.5: py35, docs
   3.6: py36, docs
@@ -17,12 +16,6 @@ DJANGO =
 commands = python runtests.py
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cid
-
-[testenv:py27-django1.11]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.11,<2
 
 [testenv:py34-django1.11]
 basepython = python3.4


### PR DESCRIPTION
The "extended support" of Django 1.10 was ended in December 2017 [1].
It's time to move on. Only Django 1.11 is now supported, with
reasonably recent versions of Python (2.7 or >=3.4).

Support of Django 2 will soon be added.

[1] https://www.djangoproject.com/download/